### PR TITLE
only update glossary page

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -4,49 +4,81 @@ title: Glossary
 
 
 <h5 id="b">B-mode</h5>
-B-mode
+
 : B-mode is short for brightness mode of ultrasound. It is a mode in which 2-D cross sectional images are made with highly echogenic tissues are represented with bright pixels.
 
+---
 
-Brain Imaging Data Structure (BIDS)
+<h5 id="bids"> Brain Imaging Data Structure (BIDS)</h5>
+
 : BIDS is a standardized way of organizing and describing neuroimaging and behavioral data. It aims to simplify data sharing and analysis by providing a consistent file structure and naming convention across different studies and institutions.
 
-Computed tomography (CT)
+---
+
+<h5 id="ct">Computed tomography (CT)</h5>
+
 : A CT scan uses X-rays and computer processing to create cross-sectional images of the body. Multiple X-ray measurements are taken from different angles to produce detailed slices that can be combined into three-dimensional representations, providing more comprehensive information than traditional X-rays.
 
-Digital Imaging and Communications in Medicine (DICOM)
+
+---
+
+<h5 id="dicom">Digital Imaging and Communications in Medicine (DICOM)</h5>
+
 : DICOM is both a file format and a communication protocol standard for medical imaging. It allows for the integration of medical imaging devices, servers, workstations, printers, and network hardware from multiple manufacturers into a comprehensive information system.
 
-Large language model (LLM)
+---
+
+
+<h5 id="llm">Large language model (LLM)</h5>
+
 : A LLM is a type of AI model primarily defined by the size of its training data rather than its architecture. Initially, most LLMs were based on transformer architecture, but other types have since emerged. Multimodal LLMs can handle multiple types of input and output, such as text and images.
 
-Magnetic resonance imaging (MRI)
+---
+
+
+<h5 id="mri">Magnetic resonance imaging (MRI)</h5>
+
 : MRI is a non-invasive imaging technique that uses strong magnetic fields and radio waves to generate detailed images of organs and tissues. It's particularly useful for visualizing soft tissues and doesn't use ionizing radiation, making it suitable for repeated scans.
 
-<h5 id="b">Morphological operations</h5>
-Morphological Operations
+---
+
+<h5 id="morph">Morphological Operations</h5>
+
 : Morphological operations are image processing operations that are based on shapes of objects within an image. Two critical operations for several compound operations are erosion or dilation. Erosion shrinks an object within an image. Dilation expands an object within an image. In both cases the change is based on a structuring element, which is a predefined shape. Opening, closing and morphological gradient are morphologicl operations based on combining erosion and dilation.
 
-Neuroimaging Informatics Technology Initiative (NIfTI)
+
+---
+
+
+<h5 id="nifti">Neuroimaging Informatics Technology Initiative (NIfTI)</h5>
+
 : NIfTI is a file format commonly used in neuroimaging to store and share brain imaging data. It was developed to address limitations in previous formats and includes support for storing image orientation and other metadata crucial for accurate analysis.
 
-Positron emission tomography (PET)
+---
+
+<h5 id="pet">Positron emission tomography (PET)</h5>
+
 : A PET scan involves the use of radioactive tracers, such as Fluorodeoxyglucose or Oxygen-15 (15O), which are administered to the patient. Gamma ray detectors then create an image based on the tracer's distribution in the body. PET scans can be combined with or registered to other forms of imaging for enhanced diagnostic accuracy.
 
+----
 
+<h5 id="rad">Radiomics</h5>
 
-Radiomics
 : Radiomics implies a quantitiative approach to medical image analysis. Quantitative features are extracted from medical images using data-characterization algorithms. These features, which may not be visible to the human eye, can potentially be used for improved diagnosis, prognosis, and treatment planning.
 
+---
 
 <h5 id="Registration">Registration</h5>
-Registration
+
 : Image registration is a process by which different images of the same object are aligned on the same coordinate system. This process usually requires transformation of at least one of the images. In an example where one image was taken with a patient lying face down and the other image with the patient face up, one of the images will have to be flipped about 180 degrees to register the images. 
 
+----
 
 <h5 id="sinogram">Sinogram</h5>
-Sinogram
+
 : Sinogram is a word with multiple definitions in radiology. Sinogram may refer to an X-ray of the sinuses or imaging or a fistule.  However in terms of CT reconstruction it refers to the data from which a final CT is reconstructed. The raw data of CT is a lot of 2D projections (a lot of X-rays). A sinogram is a way to visualize this data by having the angle as one of the axes of the image. 
 
-Tag image file format (TIFF)
+---
+<h5 id="tiff">Tag image file format (TIFF)</h5>
+
 : TIFF files conform to the Tag Image File Format standard and can store grayscale or color images as raster images. They support both lossy and lossless compression, and can also be left uncompressed.


### PR DESCRIPTION
This only updates the glossary page to a correct working format. All other pages should update with correct links as they are changed. An example of an already working link is B-mode. 