### PR TITLE
Clarify that source lessons are from the Incubator

### DIFF
--- a/episodes/mri.md
+++ b/episodes/mri.md
@@ -27,7 +27,7 @@ exercises: 10
 
 ## Introduction
 
-This lesson is heavily based on existing lessons from Carpentries; namely:
+This lesson is heavily based on existing lessons from The Carpentries Incubator; namely:
 
  1. [Introduction to Working with MRI Data in Python](https://carpentries-incubator.github.io/SDC-BIDS-IntroMRI/)
  2. [Introduction to dMRI](https://carpentries-incubator.github.io/SDC-BIDS-dMRI/)


### PR DESCRIPTION
A minor clarification, to make clear that the lessons cited in the [introduction to the _Working with MRI_ episode](https://carpentries-incubator.github.io/medical-image-processing/mri.html#introduction) are from the Incubator, as opposed to official curriculum of The Carpentries.